### PR TITLE
Parse assets, not just data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,24 +19,9 @@ jobs:
   test-parse:
     name: Data Files
     runs-on: windows-2022
-    env:
-      CONTINUOUS: EndlessSky-win64-continuous.zip
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    needs: changed
+    if: ${{ needs.changed.outputs.workflows == 'true' || needs.changed.outputs.data_files == 'true' }}
     steps:
-    - name: Download latest continuous
-      run: gh release download -R endless-sky/endless-sky continuous -p ${{ env.CONTINUOUS }}
-    - name: Extract and prepare continuous
-      run: |
-        Expand-Archive ${{ env.CONTINUOUS }} -DestinationPath endless-sky -Force
-        cd .\endless-sky
-        mkdir plugins
-        cd .\plugins
-        mkdir blended-ships
-    - uses: actions/checkout@v5.0.0
+    - uses: warp-core/endless-sky-test-parse@master
       with:
-        path: '.\endless-sky\plugins\blended-ships'
-    - name: Parse Datafiles
-      run: "'.\\endless-sky\\Endless Sky.exe' --parse-assets"
-      shell: bash
-
-
+        parse-assets: true


### PR DESCRIPTION
I see I'm not the only one to fall victim to this...
Updates the definition of warp-core's check so that it also flags issues with images and sounds. Now it's easier to spot errors ~~before ziproot does~~.

Checks on this should fail, since the Model 192 has image errors.